### PR TITLE
scoutfs-tests: add setattr_more tests

### DIFF
--- a/golden/setattr_more
+++ b/golden/setattr_more
@@ -1,0 +1,29 @@
+== 0 data_version arg fails
+setattr_more ioctl failed on '/mnt/test/test/setattr_more/file': Invalid argument (22)
+scoutfs: setattr failed: Invalid argument (22)
+== args must specify size and offline
+setattr_more ioctl failed on '/mnt/test/test/setattr_more/file': Invalid argument (22)
+scoutfs: setattr failed: Invalid argument (22)
+== only works on regular files
+failed to open '/mnt/test/test/setattr_more/dir': Is a directory (21)
+scoutfs: setattr failed: Is a directory (21)
+setattr_more ioctl failed on '/mnt/test/test/setattr_more/char': Inappropriate ioctl for device (25)
+scoutfs: setattr failed: Inappropriate ioctl for device (25)
+== non-zero file size fails
+setattr_more ioctl failed on '/mnt/test/test/setattr_more/file': Invalid argument (22)
+scoutfs: setattr failed: Invalid argument (22)
+== non-zero file data_version fails
+setattr_more ioctl failed on '/mnt/test/test/setattr_more/file': Invalid argument (22)
+scoutfs: setattr failed: Invalid argument (22)
+== large size is set
+578437695752307201
+== large data_version is set
+578437695752307201
+== large ctime is set
+1972-02-19 00:06:25.999999999 +0000
+== large offline extents are created
+Filesystem type is: 554f4353
+File size of /mnt/test/test/setattr_more/file is 40988672 (10007 blocks of 4096 bytes)
+ ext:     logical_offset:        physical_offset: length:   expected: flags:
+   0:        0..   10239:          0..     10239:  10240:             unknown,eof
+/mnt/test/test/setattr_more/file: 1 extent found

--- a/sequence
+++ b/sequence
@@ -4,6 +4,7 @@ inode-items-updated.sh
 simple-inode-index.sh
 simple-staging.sh
 simple-release-extents.sh
+setattr_more.sh
 offline-extent-waiting.sh
 simple-xattr-unit.sh
 lock-refleak.sh

--- a/tests/setattr_more.sh
+++ b/tests/setattr_more.sh
@@ -1,0 +1,64 @@
+#
+# Test correctness of the setattr_more ioctl.
+#
+
+t_require_commands filefrag scoutfs touch mkdir rm stat mknod
+
+FILE="$T_D0/file"
+
+echo "== 0 data_version arg fails"
+touch "$FILE"
+scoutfs setattr -d 0 -s 1 -f "$FILE" 2>&1 | t_filter_fs
+rm "$FILE"
+
+echo "== args must specify size and offline"
+touch "$FILE"
+scoutfs setattr -d 1 -o -s 0 -f "$FILE" 2>&1 | t_filter_fs
+rm "$FILE"
+
+echo "== only works on regular files"
+mkdir "$T_D0/dir"
+scoutfs setattr -d 1 -s 1 -f "$T_D0/dir" 2>&1 | t_filter_fs
+rmdir "$T_D0/dir"
+mknod "$T_D0/char" c 1 3
+scoutfs setattr -d 1 -s 1 -f "$T_D0/char" 2>&1 | t_filter_fs
+rm "$T_D0/char"
+
+echo "== non-zero file size fails"
+echo contents > "$FILE"
+scoutfs setattr -d 1 -s 1 -f "$FILE" 2>&1 | t_filter_fs
+rm "$FILE"
+
+echo "== non-zero file data_version fails"
+touch "$FILE"
+truncate -s 1M "$FILE"
+truncate -s 0 "$FILE"
+scoutfs setattr -d 1 -o -s 1 -f "$FILE" 2>&1 | t_filter_fs
+rm "$FILE"
+
+echo "== large size is set"
+touch "$FILE"
+scoutfs setattr -d 1 -s 578437695752307201 -f "$FILE" 2>&1 | t_filter_fs
+stat -c "%s" "$FILE"
+rm "$FILE"
+
+echo "== large data_version is set"
+touch "$FILE"
+scoutfs setattr -d 578437695752307201 -s 1 -f "$FILE" 2>&1 | t_filter_fs
+scoutfs stat -s data_version "$FILE"
+rm "$FILE"
+
+echo "== large ctime is set"
+touch "$FILE"
+# only doing 32bit sec 'cause stat gets confused
+scoutfs setattr -c 67305985.999999999 -d 1 -s 1 -f "$FILE" 2>&1 | t_filter_fs
+TZ=GMT stat -c "%z" "$FILE"
+rm "$FILE"
+
+echo "== large offline extents are created"
+touch "$FILE"
+scoutfs setattr -d 1 -o -s $((10007 * 4096)) -f "$FILE" 2>&1 | t_filter_fs
+filefrag -v -b4096 "$FILE" 2>&1 | t_filter_fs
+rm "$FILE"
+
+t_pass


### PR DESCRIPTION
We had a bug where offline extent creation during setattr_more just
wasn't making it all the way to persistent items.  This adds basic
sanity tests of the setattr_more interface.

Signed-off-by: Zach Brown <zab@versity.com>