### PR TITLE
scoutfs-tests: check setattr_more offline extent

### DIFF
--- a/golden/setattr_more
+++ b/golden/setattr_more
@@ -25,5 +25,7 @@ scoutfs: setattr failed: Invalid argument (22)
 Filesystem type is: 554f4353
 File size of /mnt/test/test/setattr_more/file is 40988672 (10007 blocks of 4096 bytes)
  ext:     logical_offset:        physical_offset: length:   expected: flags:
-   0:        0..   10239:          0..     10239:  10240:             unknown,eof
+   0:        0..   10006:          0..     10006:  10007:             unknown,eof
 /mnt/test/test/setattr_more/file: 1 extent found
+== correct offline extent length
+976563

--- a/tests/setattr_more.sh
+++ b/tests/setattr_more.sh
@@ -61,4 +61,11 @@ scoutfs setattr -d 1 -o -s $((10007 * 4096)) -f "$FILE" 2>&1 | t_filter_fs
 filefrag -v -b4096 "$FILE" 2>&1 | t_filter_fs
 rm "$FILE"
 
+# had a bug where we were creating extents that were too long
+echo "== correct offline extent length"
+touch "$FILE"
+scoutfs setattr -d 1 -o -s 4000000000 -f "$FILE" 2>&1 | t_filter_fs
+scoutfs stat -s offline_blocks "$FILE"
+rm "$FILE"
+
 t_pass


### PR DESCRIPTION
We had a bug where we were creating extent lengths that were rounded up
to the size of the packed extent items instead of being limited by
i_size.  As it happens the last setattr_more test would have found it if
I'd actually done the math to check that the extent length was correct.
We add an explicit offline blocks count test because that's what lead us
to notice that the offline extent length was wrong.

Signed-off-by: Zach Brown <zab@versity.com>