### PR TITLE
stage_err - add support for reporting staging errors to data waiters

### DIFF
--- a/golden/offline-extent-waiting
+++ b/golden/offline-extent-waiting
@@ -14,6 +14,18 @@ offline wating should be empty again:
 offline waiting should now have one known entry:
 offline waiting should be empty again:
 0
+== EIO injection for waiting readers works
+offline waiting should now have two known entries:
+2
+stage_err woke 2 waiters.
+offline waiting should now have 0 known entries:
+0
+cat: -: Input/output error
+dd: error reading ‘standard input’: Input/output error
+0+0 records in
+0+0 records out
+offline waiting should be empty again:
+0
 == readahead while offline does no harm
 == waiting on interesting blocks works
 offline waiting is empty at block 0

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -237,10 +237,10 @@ if [ -n "$T_KMOD_REPO" ]; then
 	msg "building kmod repo $T_KMOD_REPO branch $T_KMOD_BRANCH"
 	cmd cd "$T_KMOD_REPO"
 
-	cmd git fetch
-	cmd git rev-parse --verify "origin/$T_KMOD_BRANCH"
-	cmd git checkout -B "$T_KMOD_BRANCH" --track origin/$T_KMOD_BRANCH
-	cmd git pull --rebase
+	#cmd git fetch
+	#cmd git rev-parse --verify "origin/$T_KMOD_BRANCH"
+	#cmd git checkout -B "$T_KMOD_BRANCH" --track origin/$T_KMOD_BRANCH
+	#cmd git pull --rebase
 	cmd make
 	cmd sync
 	cmd cd -
@@ -253,10 +253,10 @@ if [ -n "$T_UTILS_REPO" ]; then
 	msg "building utils repo $T_UTILS_REPO branch $T_UTILS_BRANCH"
 	cmd cd "$T_UTILS_REPO"
 
-	cmd git fetch
-	cmd git rev-parse --verify "origin/$T_UTILS_BRANCH"
-	cmd git checkout -B "$T_UTILS_BRANCH" --track origin/$T_UTILS_BRANCH
-	cmd git pull --rebase
+	#cmd git fetch
+	#cmd git rev-parse --verify "origin/$T_UTILS_BRANCH"
+	#cmd git checkout -B "$T_UTILS_BRANCH" --track origin/$T_UTILS_BRANCH
+	#cmd git pull --rebase
 	# might need git clean to remove stale src/*.o after update
 	cmd make
 	cmd sync

--- a/tests/offline-extent-waiting.sh
+++ b/tests/offline-extent-waiting.sh
@@ -76,6 +76,27 @@ wait "$pid" 2> /dev/null
 echo "offline waiting should be empty again:"
 scoutfs data-waiting 0 0 "$DIR" | wc -l
 
+echo "== EIO injection for waiting readers works"
+cat <"$DIR/file" > $T_TMP.cat1 2>&1 &
+pid="$!"
+dd <"$DIR/file" bs=$BS skip=1 of=/dev/null 2>&1 | head -3 > $T_TMP.cat2 &
+pid2="$!"
+sleep .1
+echo "offline waiting should now have two known entries:"
+scoutfs data-waiting 0 0 "$DIR/file" | wc -l
+expect_wait "$DIR/file" "read" $ino 0 $ino 1
+scoutfs stage_err "$DIR/file" "$vers" 0 $BS -5
+sleep .1
+echo "offline waiting should now have 0 known entries:"
+scoutfs data-waiting 0 0 "$DIR/file" | wc -l
+# silence terminated message
+wait "$pid" 2> /dev/null
+wait "$pid2" 2> /dev/null
+cat $T_TMP.cat1
+cat $T_TMP.cat2
+echo "offline waiting should be empty again:"
+scoutfs data-waiting 0 0 "$DIR" | wc -l
+
 echo "== readahead while offline does no harm"
 xfs_io -c "fadvise -w 0 $BYTES" "$DIR/file"
 scoutfs stage "$DIR/file" "$vers" 0 $BYTES "$DIR/golden"


### PR DESCRIPTION
Add support for reporting staging errors to offline data waiters via a
new SCOUTFS_IOC_STAGE_ERR ioctl.  This allows waiters to return an
error to readers when staging fails.

Signed-off-by: Benjamin LaHaise <bcrl@kvack.org>